### PR TITLE
ci: add build workflow for client and server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - name: Install server dependencies
+        run: npm ci
+        working-directory: server
+      - name: Check server syntax
+        run: node --check index.js
+        working-directory: server
+      - name: Install client dependencies
+        run: npm ci
+        working-directory: client
+      - name: Build client
+        run: npm run build
+        working-directory: client


### PR DESCRIPTION
Adds a CI workflow that installs dependencies, syntax-checks the server entry, and builds the Vite client on push and PR to main.